### PR TITLE
fix the crash while plugin's owner is nil.

### DIFF
--- a/Sketch Toolbox/STPluginCellView.m
+++ b/Sketch Toolbox/STPluginCellView.m
@@ -30,7 +30,7 @@
 -(void)populate {
     self.nameButton.title = self.plugin.displayName;
     self.descriptionField.stringValue = self.plugin.desc;
-    self.owner.stringValue = self.plugin.owner;
+    self.owner.stringValue = self.plugin.owner ?: @"";
     self.starCount.stringValue = [NSString stringWithFormat:@"%i", self.plugin.stars];
     if (self.plugin.state == PluginStateInstalled) {
         [self.actionButton setTitle:@"Uninstall"];


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5976778/28365895-fab338ca-6cbc-11e7-9e9c-aad0805d4fed.png)
while plugin's owner is nil, here will crash:
location: STPluginCellView.m -(void)populate line:34.
![image](https://user-images.githubusercontent.com/5976778/28365918-10e1cee0-6cbd-11e7-8479-407c19394811.png)
you can replace the code to fix the crash:
![image](https://user-images.githubusercontent.com/5976778/28365928-19eaf278-6cbd-11e7-83af-c945eb4bee45.png)
